### PR TITLE
proto version with dl link i386 latest, silicon hardcoded

### DIFF
--- a/fragments/labels/wrikeformac.sh
+++ b/fragments/labels/wrikeformac.sh
@@ -1,0 +1,12 @@
+wrikeformac)
+    name="Wrike for Mac"
+    type="dmg"
+    if [[ $(arch) == i386 ]]; then
+        downloadURL="https://dl.wrike.com/download/WrikeDesktopApp.latest.dmg"
+    elif [[ $(arch) == arm64 ]]; then
+        #downloadURL="https://dl.wrike.com/download/WrikeDesktopApp_ARM.latest.dmg"  # ne marche pas avec latest, il faut obligatoirement un numéro de version 
+        downloadURL="https://dl.wrike.com/download/WrikeDesktopApp_ARM.v4.0.6.dmg"
+    fi
+    appNewVersion=""
+    expectedTeamID="BD3YL53XT4"
+    ;;


### PR DESCRIPTION
first working version with dl link
- for i386, download link with latest is functionna
- for silicon, download link must contain version number, but no alid source has been found yet to determine existing versions, hardcoded to v4.0.6 for now